### PR TITLE
[iOS] 이슈 편집 기능

### DIFF
--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -183,9 +183,9 @@
 			children = (
 				AE7D391A2671A91400BF9487 /* UINibCreatable.swift */,
 				AE7D39422672033800BF9487 /* UIView+HiddenWithAnimation.swift */,
-				AE7D39402671E8CC00BF9487 /* Notification+Name.swift */,
-				AE7505322670EE0600BA14F7 /* UIColor+hexToUIColor.swift */,
 				AE7505302670ED1F00BA14F7 /* UILabel+AddLineSpacing.swift */,
+				AE7505322670EE0600BA14F7 /* UIColor+hexToUIColor.swift */,
+				AE7D39402671E8CC00BF9487 /* Notification+Name.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";

--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AE7D392E2671B6EF00BF9487 /* Milestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF89A99C2670784200983577 /* Milestone.swift */; };
 		AE7D39362671BC7200BF9487 /* UtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7D39352671BC7200BF9487 /* UtilityTests.swift */; };
 		AE7D393D2671BC9400BF9487 /* UIColor+hexToUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7505322670EE0600BA14F7 /* UIColor+hexToUIColor.swift */; };
+		AE7D39412671E8CC00BF9487 /* Notification+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7D39402671E8CC00BF9487 /* Notification+Name.swift */; };
 		AECEA442266F38D000855F20 /* IssueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECEA441266F38D000855F20 /* IssueDataSource.swift */; };
 		AECEA445266F3AD900855F20 /* IssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECEA443266F3AD900855F20 /* IssueCell.swift */; };
 		AECEA446266F3AD900855F20 /* IssueCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AECEA444266F3AD900855F20 /* IssueCell.xib */; };
@@ -80,6 +81,7 @@
 		AE7D39332671BC7200BF9487 /* UtilityTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UtilityTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AE7D39352671BC7200BF9487 /* UtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTests.swift; sourceTree = "<group>"; };
 		AE7D39372671BC7200BF9487 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		AE7D39402671E8CC00BF9487 /* Notification+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Name.swift"; sourceTree = "<group>"; };
 		AECEA441266F38D000855F20 /* IssueDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDataSource.swift; sourceTree = "<group>"; };
 		AECEA443266F3AD900855F20 /* IssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCell.swift; sourceTree = "<group>"; };
 		AECEA444266F3AD900855F20 /* IssueCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCell.xib; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 			isa = PBXGroup;
 			children = (
 				AE7D391A2671A91400BF9487 /* UINibCreatable.swift */,
+				AE7D39402671E8CC00BF9487 /* Notification+Name.swift */,
 				AE7505322670EE0600BA14F7 /* UIColor+hexToUIColor.swift */,
 				AE7505302670ED1F00BA14F7 /* UILabel+AddLineSpacing.swift */,
 			);
@@ -503,6 +506,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AE7D39412671E8CC00BF9487 /* Notification+Name.swift in Sources */,
 				AECEA445266F3AD900855F20 /* IssueCell.swift in Sources */,
 				AECEA442266F38D000855F20 /* IssueDataSource.swift in Sources */,
 				FF89A962266F0BD000983577 /* IssueListViewController.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		AE7D39362671BC7200BF9487 /* UtilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7D39352671BC7200BF9487 /* UtilityTests.swift */; };
 		AE7D393D2671BC9400BF9487 /* UIColor+hexToUIColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7505322670EE0600BA14F7 /* UIColor+hexToUIColor.swift */; };
 		AE7D39412671E8CC00BF9487 /* Notification+Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7D39402671E8CC00BF9487 /* Notification+Name.swift */; };
+		AE7D39432672033800BF9487 /* UIView+HiddenWithAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE7D39422672033800BF9487 /* UIView+HiddenWithAnimation.swift */; };
 		AECEA442266F38D000855F20 /* IssueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECEA441266F38D000855F20 /* IssueDataSource.swift */; };
 		AECEA445266F3AD900855F20 /* IssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECEA443266F3AD900855F20 /* IssueCell.swift */; };
 		AECEA446266F3AD900855F20 /* IssueCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AECEA444266F3AD900855F20 /* IssueCell.xib */; };
@@ -82,6 +83,7 @@
 		AE7D39352671BC7200BF9487 /* UtilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityTests.swift; sourceTree = "<group>"; };
 		AE7D39372671BC7200BF9487 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		AE7D39402671E8CC00BF9487 /* Notification+Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification+Name.swift"; sourceTree = "<group>"; };
+		AE7D39422672033800BF9487 /* UIView+HiddenWithAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+HiddenWithAnimation.swift"; sourceTree = "<group>"; };
 		AECEA441266F38D000855F20 /* IssueDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDataSource.swift; sourceTree = "<group>"; };
 		AECEA443266F3AD900855F20 /* IssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCell.swift; sourceTree = "<group>"; };
 		AECEA444266F3AD900855F20 /* IssueCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCell.xib; sourceTree = "<group>"; };
@@ -180,6 +182,7 @@
 			isa = PBXGroup;
 			children = (
 				AE7D391A2671A91400BF9487 /* UINibCreatable.swift */,
+				AE7D39422672033800BF9487 /* UIView+HiddenWithAnimation.swift */,
 				AE7D39402671E8CC00BF9487 /* Notification+Name.swift */,
 				AE7505322670EE0600BA14F7 /* UIColor+hexToUIColor.swift */,
 				AE7505302670ED1F00BA14F7 /* UILabel+AddLineSpacing.swift */,
@@ -508,6 +511,7 @@
 			files = (
 				AE7D39412671E8CC00BF9487 /* Notification+Name.swift in Sources */,
 				AECEA445266F3AD900855F20 /* IssueCell.swift in Sources */,
+				AE7D39432672033800BF9487 /* UIView+HiddenWithAnimation.swift in Sources */,
 				AECEA442266F38D000855F20 /* IssueDataSource.swift in Sources */,
 				FF89A962266F0BD000983577 /* IssueListViewController.swift in Sources */,
 				FF89A95E266F0BD000983577 /* AppDelegate.swift in Sources */,

--- a/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/ios/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -23,7 +23,6 @@
 		AECEA442266F38D000855F20 /* IssueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECEA441266F38D000855F20 /* IssueDataSource.swift */; };
 		AECEA445266F3AD900855F20 /* IssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AECEA443266F3AD900855F20 /* IssueCell.swift */; };
 		AECEA446266F3AD900855F20 /* IssueCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AECEA444266F3AD900855F20 /* IssueCell.xib */; };
-		AEE2A4D126709D8400FA6274 /* IssueTableDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2A4D026709D8400FA6274 /* IssueTableDelegate.swift */; };
 		AEE2A4D32670A00300FA6274 /* IssueViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2A4D22670A00300FA6274 /* IssueViewModel.swift */; };
 		AEE2A4D52670A8C000FA6274 /* LabelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE2A4D42670A8C000FA6274 /* LabelView.swift */; };
 		FF89A95E266F0BD000983577 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF89A95D266F0BD000983577 /* AppDelegate.swift */; };
@@ -87,7 +86,6 @@
 		AECEA441266F38D000855F20 /* IssueDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueDataSource.swift; sourceTree = "<group>"; };
 		AECEA443266F3AD900855F20 /* IssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCell.swift; sourceTree = "<group>"; };
 		AECEA444266F3AD900855F20 /* IssueCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCell.xib; sourceTree = "<group>"; };
-		AEE2A4D026709D8400FA6274 /* IssueTableDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueTableDelegate.swift; sourceTree = "<group>"; };
 		AEE2A4D22670A00300FA6274 /* IssueViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueViewModel.swift; sourceTree = "<group>"; };
 		AEE2A4D42670A8C000FA6274 /* LabelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelView.swift; sourceTree = "<group>"; };
 		FF89A95A266F0BD000983577 /* IssueTracker.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = IssueTracker.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,7 +153,6 @@
 			children = (
 				FF89A961266F0BD000983577 /* IssueListViewController.swift */,
 				AECEA441266F38D000855F20 /* IssueDataSource.swift */,
-				AEE2A4D026709D8400FA6274 /* IssueTableDelegate.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -526,7 +523,6 @@
 				AE7505332670EE0600BA14F7 /* UIColor+hexToUIColor.swift in Sources */,
 				FF89A997267075CD00983577 /* Issue.swift in Sources */,
 				FF89A99D2670784200983577 /* Milestone.swift in Sources */,
-				AEE2A4D126709D8400FA6274 /* IssueTableDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
-    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -13,11 +12,11 @@
             <objects>
                 <viewController id="BYZ-38-t0r" customClass="IssueListViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cak-ug-Cwp">
-                                <rect key="frame" x="24" y="68" width="51" height="22"/>
+                                <rect key="frame" x="24" y="24" width="51" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="22" id="Li9-v6-0vt"/>
                                 </constraints>
@@ -27,14 +26,14 @@
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nsR-uf-1Tl">
-                                <rect key="frame" x="336" y="68" width="30" height="30"/>
+                                <rect key="frame" x="546" y="24" width="30" height="30"/>
                                 <state key="normal" title="편집"/>
                                 <connections>
                                     <action selector="editButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Alt-dU-c31"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="이슈" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWm-lO-Mc5">
-                                <rect key="frame" x="20" y="106" width="65" height="42"/>
+                                <rect key="frame" x="20" y="62" width="65" height="42"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="65" id="Ezs-61-m9x"/>
                                 </constraints>
@@ -43,11 +42,11 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Search" translatesAutoresizingMaskIntoConstraints="NO" id="lz8-qn-0a9">
-                                <rect key="frame" x="15" y="156" width="360" height="58"/>
+                                <rect key="frame" x="15" y="112" width="570" height="102"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Edi-d5-JJ0" userLabel="LineView">
-                                <rect key="frame" x="0.0" y="222" width="390" height="1"/>
+                                <rect key="frame" x="0.0" y="222" width="600" height="1"/>
                                 <color key="backgroundColor" red="0.93717283009999997" green="0.93730747699999994" blue="0.9410645366" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="n5z-jD-Sr1"/>
@@ -59,15 +58,15 @@
                                 <color key="backgroundColor" red="0.93321973089999999" green="0.93331867459999995" blue="0.93730396029999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="0KX-iF-s2p">
-                                <rect key="frame" x="0.0" y="223" width="390" height="587"/>
+                                <rect key="frame" x="0.0" y="223" width="600" height="377"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" red="0.93717283009999997" green="0.93730747699999994" blue="0.9410645366" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="S1q-Uk-oFA">
-                                        <rect key="frame" x="0.0" y="24.333333969116211" width="390" height="44"/>
+                                        <rect key="frame" x="0.0" y="24.5" width="600" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="S1q-Uk-oFA" id="4Is-ba-lga">
-                                            <rect key="frame" x="0.0" y="0.0" width="390" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -75,10 +74,10 @@
                                 </prototypes>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fxi-wH-60j" userLabel="EditView">
-                                <rect key="frame" x="0.0" y="764" width="390" height="80"/>
+                                <rect key="frame" x="0.0" y="520" width="600" height="80"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈를 선택하세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mEU-Sh-IEt">
-                                        <rect key="frame" x="141" y="15" width="108" height="18"/>
+                                        <rect key="frame" x="246" y="15" width="108" height="18"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                         <color key="textColor" systemColor="secondaryLabelColor"/>
                                         <nil key="highlightedColor"/>
@@ -95,7 +94,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pJP-Bu-6WT">
-                                        <rect key="frame" x="340" y="0.0" width="40" height="40"/>
+                                        <rect key="frame" x="550" y="0.0" width="40" height="40"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="40" id="5EF-wf-HOr"/>
                                             <constraint firstAttribute="width" constant="40" id="zgF-J1-sGh"/>
@@ -115,7 +114,7 @@
                                 </constraints>
                             </view>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SWi-eK-cor">
-                                <rect key="frame" x="316" y="700" width="50" height="50"/>
+                                <rect key="frame" x="526" y="490" width="50" height="50"/>
                                 <color key="backgroundColor" red="0.28222963210000002" green="0.52160656449999998" blue="0.76460951570000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="9AB-Fc-gZq"/>
@@ -163,7 +162,7 @@
                     <connections>
                         <outlet property="checkAllButton" destination="GF4-Og-PDE" id="9nB-cW-n4q"/>
                         <outlet property="editButton" destination="nsR-uf-1Tl" id="cp1-ae-vMc"/>
-                        <outlet property="editableView" destination="Fxi-wH-60j" id="cb4-yy-PpK"/>
+                        <outlet property="editStateView" destination="Fxi-wH-60j" id="cb4-yy-PpK"/>
                         <outlet property="filterButton" destination="Cak-ug-Cwp" id="g2p-M3-Wsl"/>
                         <outlet property="issueLabel" destination="YWm-lO-Mc5" id="jSE-xO-WE8"/>
                         <outlet property="issueNumLabel" destination="mEU-Sh-IEt" id="Ywd-ag-IRz"/>

--- a/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -34,7 +34,10 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="이슈" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWm-lO-Mc5">
-                                <rect key="frame" x="23.999999999999996" y="106" width="60.666666666666657" height="42"/>
+                                <rect key="frame" x="20" y="106" width="65" height="42"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="65" id="Ezs-61-m9x"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -132,11 +135,10 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="YWm-lO-Mc5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="1xL-9h-nTM"/>
+                            <constraint firstItem="YWm-lO-Mc5" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="1xL-9h-nTM"/>
                             <constraint firstItem="lz8-qn-0a9" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" constant="-15" id="37B-dR-s5k"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="0KX-iF-s2p" secondAttribute="bottom" id="546-ug-d4l"/>
                             <constraint firstItem="Fxi-wH-60j" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="8j3-EY-tut"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="YWm-lO-Mc5" secondAttribute="trailing" constant="305.33333333333337" id="Af1-O3-wLj"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="nsR-uf-1Tl" secondAttribute="trailing" constant="24" id="DkN-GV-3eG"/>
                             <constraint firstItem="nsR-uf-1Tl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Cak-ug-Cwp" secondAttribute="trailing" constant="8" symbolic="YES" id="LmH-r4-C70"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="SWi-eK-cor" secondAttribute="trailing" constant="24" id="M2S-A6-zyS"/>
@@ -163,7 +165,8 @@
                         <outlet property="editButton" destination="nsR-uf-1Tl" id="cp1-ae-vMc"/>
                         <outlet property="editableView" destination="Fxi-wH-60j" id="cb4-yy-PpK"/>
                         <outlet property="filterButton" destination="Cak-ug-Cwp" id="g2p-M3-Wsl"/>
-                        <outlet property="issueNumLabel" destination="YWm-lO-Mc5" id="x0o-hS-TUH"/>
+                        <outlet property="issueLabel" destination="YWm-lO-Mc5" id="jSE-xO-WE8"/>
+                        <outlet property="issueNumLabel" destination="mEU-Sh-IEt" id="Ywd-ag-IRz"/>
                         <outlet property="issueTableView" destination="0KX-iF-s2p" id="RYH-QS-GQl"/>
                         <outlet property="plusButton" destination="SWi-eK-cor" id="D43-er-4f4"/>
                         <outlet property="searchBar" destination="lz8-qn-0a9" id="eXb-q5-GHi"/>

--- a/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
+++ b/ios/IssueTracker/IssueTracker/Base.lproj/Main.storyboard
@@ -16,22 +16,31 @@
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cak-ug-Cwp">
-                                <rect key="frame" x="24" y="68" width="35" height="30"/>
-                                <state key="normal" title="Filter"/>
+                            <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="751" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cak-ug-Cwp">
+                                <rect key="frame" x="24" y="68" width="51" height="22"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="22" id="Li9-v6-0vt"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <state key="normal" title=" 필터" image="line.horizontal.3.decrease" catalog="system">
+                                    <color key="titleColor" systemColor="systemBlueColor"/>
+                                </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nsR-uf-1Tl">
                                 <rect key="frame" x="336" y="68" width="30" height="30"/>
-                                <state key="normal" title="Edit"/>
+                                <state key="normal" title="편집"/>
+                                <connections>
+                                    <action selector="editButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Alt-dU-c31"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="이슈" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YWm-lO-Mc5">
-                                <rect key="frame" x="23.999999999999996" y="114" width="60.666666666666657" height="42"/>
+                                <rect key="frame" x="23.999999999999996" y="106" width="60.666666666666657" height="42"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="35"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <searchBar contentMode="redraw" searchBarStyle="minimal" placeholder="Search" translatesAutoresizingMaskIntoConstraints="NO" id="lz8-qn-0a9">
-                                <rect key="frame" x="15" y="164" width="360" height="50"/>
+                                <rect key="frame" x="15" y="156" width="360" height="58"/>
                                 <textInputTraits key="textInputTraits"/>
                             </searchBar>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Edi-d5-JJ0" userLabel="LineView">
@@ -41,7 +50,7 @@
                                     <constraint firstAttribute="height" constant="1" id="n5z-jD-Sr1"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" id="2hM-sJ-yUB">
+                            <view contentMode="scaleToFill" id="2hM-sJ-yUB" userLabel="BackgroundView">
                                 <rect key="frame" x="0.0" y="223" width="390" height="621"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <color key="backgroundColor" red="0.93321973089999999" green="0.93331867459999995" blue="0.93730396029999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -62,8 +71,48 @@
                                     </tableViewCell>
                                 </prototypes>
                             </tableView>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Fxi-wH-60j" userLabel="EditView">
+                                <rect key="frame" x="0.0" y="764" width="390" height="80"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈를 선택하세요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mEU-Sh-IEt">
+                                        <rect key="frame" x="141" y="15" width="108" height="18"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                        <color key="textColor" systemColor="secondaryLabelColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GF4-Og-PDE">
+                                        <rect key="frame" x="10" y="0.0" width="40" height="40"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="40" id="ZWE-kL-wID"/>
+                                            <constraint firstAttribute="width" constant="40" id="pup-mP-NB4"/>
+                                        </constraints>
+                                        <state key="normal" image="checkmark.circle" catalog="system"/>
+                                        <connections>
+                                            <action selector="checkAllButtonTouched:" destination="BYZ-38-t0r" eventType="touchUpInside" id="CPB-hl-nUH"/>
+                                        </connections>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="pJP-Bu-6WT">
+                                        <rect key="frame" x="340" y="0.0" width="40" height="40"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="40" id="5EF-wf-HOr"/>
+                                            <constraint firstAttribute="width" constant="40" id="zgF-J1-sGh"/>
+                                        </constraints>
+                                        <state key="normal" image="archivebox" catalog="system"/>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstItem="GF4-Og-PDE" firstAttribute="leading" secondItem="Fxi-wH-60j" secondAttribute="leading" constant="10" id="0Dx-lZ-Ibv"/>
+                                    <constraint firstItem="GF4-Og-PDE" firstAttribute="top" secondItem="Fxi-wH-60j" secondAttribute="top" id="1tD-vr-kdH"/>
+                                    <constraint firstAttribute="height" constant="80" id="Cma-6l-0og"/>
+                                    <constraint firstItem="mEU-Sh-IEt" firstAttribute="top" secondItem="Fxi-wH-60j" secondAttribute="top" constant="15" id="GOC-zn-yGK"/>
+                                    <constraint firstItem="mEU-Sh-IEt" firstAttribute="centerX" secondItem="Fxi-wH-60j" secondAttribute="centerX" id="MFK-GO-WIU"/>
+                                    <constraint firstItem="pJP-Bu-6WT" firstAttribute="top" secondItem="Fxi-wH-60j" secondAttribute="top" id="Prh-pv-LI6"/>
+                                    <constraint firstAttribute="trailing" secondItem="pJP-Bu-6WT" secondAttribute="trailing" constant="10" id="Qiy-f6-mXl"/>
+                                </constraints>
+                            </view>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SWi-eK-cor">
-                                <rect key="frame" x="316" y="712" width="50" height="50"/>
+                                <rect key="frame" x="316" y="700" width="50" height="50"/>
                                 <color key="backgroundColor" red="0.28222963210000002" green="0.52160656449999998" blue="0.76460951570000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="9AB-Fc-gZq"/>
@@ -71,7 +120,7 @@
                                 </constraints>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <state key="normal" image="plus" catalog="system">
-                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large" weight="heavy"/>
+                                    <preferredSymbolConfiguration key="preferredSymbolConfiguration" scale="large" weight="semibold"/>
                                 </state>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
@@ -86,6 +135,7 @@
                             <constraint firstItem="YWm-lO-Mc5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="1xL-9h-nTM"/>
                             <constraint firstItem="lz8-qn-0a9" firstAttribute="trailing" secondItem="6Tk-OE-BBY" secondAttribute="trailing" constant="-15" id="37B-dR-s5k"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="0KX-iF-s2p" secondAttribute="bottom" id="546-ug-d4l"/>
+                            <constraint firstItem="Fxi-wH-60j" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="8j3-EY-tut"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="YWm-lO-Mc5" secondAttribute="trailing" constant="305.33333333333337" id="Af1-O3-wLj"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="nsR-uf-1Tl" secondAttribute="trailing" constant="24" id="DkN-GV-3eG"/>
                             <constraint firstItem="nsR-uf-1Tl" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Cak-ug-Cwp" secondAttribute="trailing" constant="8" symbolic="YES" id="LmH-r4-C70"/>
@@ -95,10 +145,12 @@
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="0KX-iF-s2p" secondAttribute="trailing" id="O9y-fs-Gca"/>
                             <constraint firstItem="Edi-d5-JJ0" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="P8W-ii-vX1"/>
                             <constraint firstItem="0KX-iF-s2p" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="PrH-BC-Akn"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Fxi-wH-60j" secondAttribute="trailing" id="Vh8-AQ-to5"/>
                             <constraint firstItem="lz8-qn-0a9" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="15" id="Zg8-Bs-s3I"/>
                             <constraint firstItem="lz8-qn-0a9" firstAttribute="top" secondItem="YWm-lO-Mc5" secondAttribute="bottom" constant="8" id="d0b-HB-R7S"/>
                             <constraint firstItem="nsR-uf-1Tl" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="24" id="hZh-r5-cPe"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="SWi-eK-cor" secondAttribute="bottom" constant="48" id="he2-Lp-nhf"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="SWi-eK-cor" secondAttribute="bottom" constant="60" id="he2-Lp-nhf"/>
+                            <constraint firstAttribute="bottom" secondItem="Fxi-wH-60j" secondAttribute="bottom" id="hf4-zG-gTw"/>
                             <constraint firstItem="2hM-sJ-yUB" firstAttribute="top" secondItem="Edi-d5-JJ0" secondAttribute="bottom" id="iE0-wS-A0z"/>
                             <constraint firstItem="Cak-ug-Cwp" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="24" id="qsi-Ec-KDB"/>
                             <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="Edi-d5-JJ0" secondAttribute="trailing" id="x17-bP-qmi"/>
@@ -107,7 +159,9 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="EditButton" destination="nsR-uf-1Tl" id="cp1-ae-vMc"/>
+                        <outlet property="checkAllButton" destination="GF4-Og-PDE" id="9nB-cW-n4q"/>
+                        <outlet property="editButton" destination="nsR-uf-1Tl" id="cp1-ae-vMc"/>
+                        <outlet property="editableView" destination="Fxi-wH-60j" id="cb4-yy-PpK"/>
                         <outlet property="filterButton" destination="Cak-ug-Cwp" id="g2p-M3-Wsl"/>
                         <outlet property="issueNumLabel" destination="YWm-lO-Mc5" id="x0o-hS-TUH"/>
                         <outlet property="issueTableView" destination="0KX-iF-s2p" id="RYH-QS-GQl"/>
@@ -121,9 +175,18 @@
         </scene>
     </scenes>
     <resources>
+        <image name="archivebox" catalog="system" width="128" height="106"/>
+        <image name="checkmark.circle" catalog="system" width="128" height="121"/>
+        <image name="line.horizontal.3.decrease" catalog="system" width="128" height="73"/>
         <image name="plus" catalog="system" width="128" height="113"/>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/ios/IssueTracker/IssueTracker/IssueList/Utility/Notification+Name.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/Utility/Notification+Name.swift
@@ -1,0 +1,12 @@
+//
+//  Notification+Name.swift
+//  IssueTracker
+//
+//  Created by Lia on 2021/06/10.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let deleteIssue = Notification.Name(rawValue: "deleteIssue")
+}

--- a/ios/IssueTracker/IssueTracker/IssueList/Utility/UILabel+AddLineSpacing.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/Utility/UILabel+AddLineSpacing.swift
@@ -23,3 +23,21 @@ extension UILabel {
     }
     
 }
+
+
+extension UILabel {
+    
+    private func fadeTransition(_ duration: CFTimeInterval) {
+        let animation = CATransition()
+        animation.timingFunction = CAMediaTimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
+        animation.type = CATransitionType.fade
+        animation.duration = duration
+        layer.add(animation, forKey: CATransitionType.fade.rawValue)
+    }
+    
+    func textWithAnimation(text: String, _ duration: CFTimeInterval) {
+        fadeTransition(duration)
+        self.text = text
+    }
+
+}

--- a/ios/IssueTracker/IssueTracker/IssueList/Utility/UIView+HiddenWithAnimation.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/Utility/UIView+HiddenWithAnimation.swift
@@ -1,0 +1,26 @@
+//
+//  UIView+HiddenWithAnimation.swift
+//  IssueTracker
+//
+//  Created by Lia on 2021/06/10.
+//
+
+import UIKit
+
+extension UIView {
+    func setIsHidden(_ hidden: Bool, animated: Bool) {
+        if animated {
+            if self.isHidden && !hidden {
+                self.alpha = 0.0
+                self.isHidden = false
+            }
+            UIView.animate(withDuration: 0.2, animations: {
+                self.alpha = hidden ? 0.0 : 1.0
+            }) { (complete) in
+                self.isHidden = hidden
+            }
+        } else {
+            self.isHidden = hidden
+        }
+    }
+}

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -13,8 +13,12 @@ class IssueListViewController: UIViewController {
     @IBOutlet private weak var searchBar: UISearchBar!
     @IBOutlet private weak var issueTableView: UITableView!
     @IBOutlet private weak var filterButton: UIButton!
-    @IBOutlet private weak var EditButton: UIButton!
+    @IBOutlet private weak var editButton: UIButton!
     @IBOutlet private weak var plusButton: UIButton!
+    
+    @IBOutlet weak var editableView: UIView!
+    @IBOutlet weak var checkAllButton: UIButton!
+    private var isCheckAll: Bool!
     
     private var viewModel: IssueViewModel!
     private var dataSource: IssueDataSource!
@@ -42,6 +46,8 @@ extension IssueListViewController: UITableViewDelegate {
         issueTableView.dataSource = dataSource
         issueTableView.delegate = tableViewDelegate
         issueTableView.register(UINib(nibName: IssueCell.reuseIdentifier, bundle: nil), forCellReuseIdentifier: IssueCell.reuseIdentifier)
+        issueTableView.allowsMultipleSelectionDuringEditing = true
+        editableView.isHidden = true
     }
     
 }
@@ -66,3 +72,34 @@ extension IssueListViewController {
     }
     
 }
+
+
+extension IssueListViewController {
+    
+    @IBAction private func editButtonTouched(_ sender: UIButton) {
+        issueTableView.isEditing = !issueTableView.isEditing
+        issueTableView.setEditing(issueTableView.isEditing, animated: true)
+        editButton.setTitle(issueTableView.isEditing ? "취소" : "편집", for: .normal)
+        filterButton.setIsHidden(issueTableView.isEditing, animated: true)
+        editableView.setIsHidden(!issueTableView.isEditing, animated: true)
+    }
+    
+    @IBAction private func checkAllButtonTouched(_ sender: UIButton) {
+        let allIndexPath = (0..<viewModel.issues.count).map { IndexPath(row: $0, section: 0) }
+        isCheckAll = issueTableView.indexPathsForSelectedRows == allIndexPath
+        
+        if isCheckAll {
+            checkAllButton.setImage(UIImage(systemName: "checkmark.circle"), for: .normal)
+            allIndexPath.forEach {
+                issueTableView.deselectRow(at: $0, animated: true)
+            }
+        } else {
+            checkAllButton.setImage(UIImage(systemName: "checkmark.circle.fill"), for: .normal)
+            allIndexPath.forEach {
+                issueTableView.selectRow(at: $0, animated: true, scrollPosition: .none)
+            }
+        }
+    }
+    
+}
+

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -16,9 +16,9 @@ class IssueListViewController: UIViewController {
     @IBOutlet private weak var editButton: UIButton!
     @IBOutlet private weak var plusButton: UIButton!
     
-    @IBOutlet weak var editableView: UIView!
-    @IBOutlet weak var issueNumLabel: UILabel!
-    @IBOutlet weak var checkAllButton: UIButton!
+    @IBOutlet private weak var editableView: UIView!
+    @IBOutlet private weak var issueNumLabel: UILabel!
+    @IBOutlet private weak var checkAllButton: UIButton!
     private var isCheckAll: Bool!
     
     private var viewModel: IssueViewModel!

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 class IssueListViewController: UIViewController {
     
-    @IBOutlet private weak var issueNumLabel: UILabel!
+    @IBOutlet private weak var issueLabel: UILabel!
     @IBOutlet private weak var searchBar: UISearchBar!
     @IBOutlet private weak var issueTableView: UITableView!
     @IBOutlet private weak var filterButton: UIButton!
@@ -17,6 +17,7 @@ class IssueListViewController: UIViewController {
     @IBOutlet private weak var plusButton: UIButton!
     
     @IBOutlet weak var editableView: UIView!
+    @IBOutlet weak var issueNumLabel: UILabel!
     @IBOutlet weak var checkAllButton: UIButton!
     private var isCheckAll: Bool!
     
@@ -75,9 +76,13 @@ extension IssueListViewController {
 extension IssueListViewController {
     
     @IBAction private func editButtonTouched(_ sender: UIButton) {
+        fillCheckButton(issueTableView)
+        changeIssueNumLabel(issueTableView)
+        
         issueTableView.isEditing = !issueTableView.isEditing
         issueTableView.setEditing(issueTableView.isEditing, animated: true)
         editButton.setTitle(issueTableView.isEditing ? "취소" : "편집", for: .normal)
+        issueLabel.textWithAnimation(text: issueTableView.isEditing ? "이슈 선택" : "이슈", 0.2)
         filterButton.setIsHidden(issueTableView.isEditing, animated: true)
         editableView.setIsHidden(!issueTableView.isEditing, animated: true)
     }
@@ -97,14 +102,17 @@ extension IssueListViewController {
                 issueTableView.selectRow(at: $0, animated: true, scrollPosition: .none)
             }
         }
+        changeIssueNumLabel(issueTableView)
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         fillCheckButton(tableView)
+        changeIssueNumLabel(tableView)
     }
     
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
         fillCheckButton(tableView)
+        changeIssueNumLabel(tableView)
     }
     
     private func fillCheckButton(_ tableView: UITableView) {
@@ -114,6 +122,17 @@ extension IssueListViewController {
             checkAllButton.setImage(UIImage(systemName: "checkmark.circle.fill"), for: .normal)
         } else {
             checkAllButton.setImage(UIImage(systemName: "checkmark.circle"), for: .normal)
+        }
+    }
+    
+    private func changeIssueNumLabel(_ tableView: UITableView) {
+        let issueNum = tableView.indexPathsForSelectedRows?.count
+        if issueNum == nil {
+            issueNumLabel.textWithAnimation(text: "이슈를 선택하세요", 0.15)
+            issueNumLabel.textColor = .secondaryLabel
+        } else {
+            issueNumLabel.textWithAnimation(text: "\(issueNum!)개의 이슈가 선택됨", 0.15)
+            issueNumLabel.textColor = .label
         }
     }
     

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -47,29 +47,44 @@ extension IssueListViewController {
         issueTableView.register(UINib(nibName: IssueCell.reuseIdentifier, bundle: nil), forCellReuseIdentifier: IssueCell.reuseIdentifier)
         issueTableView.allowsMultipleSelectionDuringEditing = true
         editableView.isHidden = true
-        setObserver()
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return UITableView.automaticDimension
     }
     
 }
 
 //MARK:- Delete Issue
 
-extension IssueListViewController {
+extension IssueListViewController: UITableViewDelegate {
     
-    private func setObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(alertForDelete), name: .deleteIssue, object: nil)
-    }
-    
-    @objc func alertForDelete(_ notification: Notification) {
-        guard let index = notification.userInfo?["index"] as? IndexPath else { return }
-        
+    private func alertForDelete(with index: IndexPath) {
         let alert = UIAlertController(title: "정말로 이 이슈를 삭제하시겠습니까?", message: "", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "취소", style: .default, handler: nil))
-        alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { action in
+        let cancel = UIAlertAction(title: "취소", style: .default, handler: nil)
+        let delete = UIAlertAction(title: "삭제", style: .destructive) { action in
             self.viewModel.deleteIssue(at: index.row)
             self.issueTableView.deleteRows(at: [index], with: UITableView.RowAnimation.automatic)
-        })
+        }
+        alert.addAction(cancel)
+        alert.addAction(delete)
         self.present(alert, animated: true, completion: nil)
+    }
+    
+    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+        let close = UIContextualAction(style: .normal, title: "Close") { action, view, completion in
+            completion(true)
+        }
+        let delete = UIContextualAction(style: .destructive, title: "Delete") { action, view, completion in
+            self.alertForDelete(with: indexPath)
+            completion(true)
+        }
+        close.image = UIImage(systemName: "archivebox")
+        delete.image = UIImage(systemName: "trash")
+        
+        let configuration = UISwipeActionsConfiguration(actions: [delete, close])
+        configuration.performsFirstActionWithFullSwipe = false
+        return configuration
     }
     
 }

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -28,11 +28,11 @@ class IssueListViewController: UIViewController {
         super.viewDidLoad()
         setViewModel(with: IssueListMock.data)
         setting()
-        setObserver()
     }
     
 }
 
+//MARK:- Set Inital Condition
 
 extension IssueListViewController {
     
@@ -47,10 +47,12 @@ extension IssueListViewController {
         issueTableView.register(UINib(nibName: IssueCell.reuseIdentifier, bundle: nil), forCellReuseIdentifier: IssueCell.reuseIdentifier)
         issueTableView.allowsMultipleSelectionDuringEditing = true
         editableView.isHidden = true
+        setObserver()
     }
     
 }
 
+//MARK:- Delete Issue
 
 extension IssueListViewController {
     
@@ -72,6 +74,7 @@ extension IssueListViewController {
     
 }
 
+//MARK:- Editing Mode
 
 extension IssueListViewController {
     

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -24,6 +24,7 @@ class IssueListViewController: UIViewController {
         super.viewDidLoad()
         setViewModel(with: IssueListMock.data)
         setting()
+        setObserver()
     }
     
 }
@@ -34,13 +35,34 @@ extension IssueListViewController: UITableViewDelegate {
     func setViewModel(with issues: [Issue]) {
         viewModel = IssueViewModel(issues: issues)
         dataSource = IssueDataSource(viewModel: viewModel)
-        tableViewDelegate = IssueTableDelegate(viewModel: viewModel)
+        tableViewDelegate = IssueTableDelegate()
     }
     
     private func setting() {
         issueTableView.dataSource = dataSource
         issueTableView.delegate = tableViewDelegate
         issueTableView.register(UINib(nibName: IssueCell.reuseIdentifier, bundle: nil), forCellReuseIdentifier: IssueCell.reuseIdentifier)
+    }
+    
+}
+
+
+extension IssueListViewController {
+    
+    private func setObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(alertForDelete), name: .deleteIssue, object: nil)
+    }
+    
+    @objc func alertForDelete(_ notification: Notification) {
+        guard let index = notification.userInfo?["index"] as? IndexPath else { return }
+        
+        let alert = UIAlertController(title: "정말로 이 이슈를 삭제하시겠습니까?", message: "", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "취소", style: .default, handler: nil))
+        alert.addAction(UIAlertAction(title: "삭제", style: .destructive) { action in
+            self.viewModel.deleteIssue(at: index.row)
+            self.issueTableView.deleteRows(at: [index], with: UITableView.RowAnimation.automatic)
+        })
+        self.present(alert, animated: true, completion: nil)
     }
     
 }

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -16,7 +16,7 @@ class IssueListViewController: UIViewController {
     @IBOutlet private weak var editButton: UIButton!
     @IBOutlet private weak var plusButton: UIButton!
     
-    @IBOutlet private weak var editableView: UIView!
+    @IBOutlet private weak var editStateView: UIView!
     @IBOutlet private weak var issueNumLabel: UILabel!
     @IBOutlet private weak var checkAllButton: UIButton!
     private var isCheckAll: Bool!
@@ -46,7 +46,7 @@ extension IssueListViewController {
         issueTableView.delegate = self
         issueTableView.register(UINib(nibName: IssueCell.reuseIdentifier, bundle: nil), forCellReuseIdentifier: IssueCell.reuseIdentifier)
         issueTableView.allowsMultipleSelectionDuringEditing = true
-        editableView.isHidden = true
+        editStateView.isHidden = true
     }
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -102,7 +102,7 @@ extension IssueListViewController {
         editButton.setTitle(issueTableView.isEditing ? "취소" : "편집", for: .normal)
         issueLabel.textWithAnimation(text: issueTableView.isEditing ? "이슈 선택" : "이슈", 0.2)
         filterButton.setIsHidden(issueTableView.isEditing, animated: true)
-        editableView.setIsHidden(!issueTableView.isEditing, animated: true)
+        editStateView.setIsHidden(!issueTableView.isEditing, animated: true)
     }
     
     @IBAction private func checkAllButtonTouched(_ sender: UIButton) {

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueListViewController.swift
@@ -22,7 +22,6 @@ class IssueListViewController: UIViewController {
     
     private var viewModel: IssueViewModel!
     private var dataSource: IssueDataSource!
-    private var tableViewDelegate: IssueTableDelegate!
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -34,17 +33,16 @@ class IssueListViewController: UIViewController {
 }
 
 
-extension IssueListViewController: UITableViewDelegate {
+extension IssueListViewController {
     
     func setViewModel(with issues: [Issue]) {
         viewModel = IssueViewModel(issues: issues)
         dataSource = IssueDataSource(viewModel: viewModel)
-        tableViewDelegate = IssueTableDelegate()
     }
     
     private func setting() {
         issueTableView.dataSource = dataSource
-        issueTableView.delegate = tableViewDelegate
+        issueTableView.delegate = self
         issueTableView.register(UINib(nibName: IssueCell.reuseIdentifier, bundle: nil), forCellReuseIdentifier: IssueCell.reuseIdentifier)
         issueTableView.allowsMultipleSelectionDuringEditing = true
         editableView.isHidden = true
@@ -98,6 +96,24 @@ extension IssueListViewController {
             allIndexPath.forEach {
                 issueTableView.selectRow(at: $0, animated: true, scrollPosition: .none)
             }
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        fillCheckButton(tableView)
+    }
+    
+    func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
+        fillCheckButton(tableView)
+    }
+    
+    private func fillCheckButton(_ tableView: UITableView) {
+        let allIndexPath = (0..<viewModel.issues.count).map { IndexPath(row: $0, section: 0) }
+        isCheckAll = tableView.indexPathsForSelectedRows == allIndexPath
+        if isCheckAll {
+            checkAllButton.setImage(UIImage(systemName: "checkmark.circle.fill"), for: .normal)
+        } else {
+            checkAllButton.setImage(UIImage(systemName: "checkmark.circle"), for: .normal)
         }
     }
     

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
@@ -7,36 +7,23 @@
 
 import UIKit
 
-class IssueTableDelegate: NSObject {
-    
-    private var viewModel: IssueViewModel
-    
-    init(viewModel: IssueViewModel) {
-        self.viewModel = viewModel
-        super.init()
-    }
-    
-}
-
-
-extension IssueTableDelegate: UITableViewDelegate {
+class IssueTableDelegate: NSObject, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
     }
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-
-            let share = UIContextualAction(style: .normal, title: "Close") { action, view, completion in
-                completion(true)
-            }
-
-            let delete = UIContextualAction(style: .destructive, title: "Delete") { [weak self] action, view, completion in
-                self?.viewModel.deleteIssue(at: indexPath.row)
-                tableView.deleteRows(at: [indexPath], with: UITableView.RowAnimation.automatic)
-                completion(true)
-            }
-
+        
+        let share = UIContextualAction(style: .normal, title: "Close") { action, view, completion in
+            completion(true)
+        }
+        
+        let delete = UIContextualAction(style: .destructive, title: "Delete") { action, view, completion in
+            NotificationCenter.default.post(name: .deleteIssue, object: nil, userInfo: ["index": indexPath])
+            completion(true)
+        }
+        
         let configuration = UISwipeActionsConfiguration(actions: [delete, share])
         configuration.performsFirstActionWithFullSwipe = false
         return configuration

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
@@ -15,16 +15,18 @@ class IssueTableDelegate: NSObject, UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         
-        let share = UIContextualAction(style: .normal, title: "Close") { action, view, completion in
+        let close = UIContextualAction(style: .normal, title: "Close") { action, view, completion in
             completion(true)
         }
+        close.image = UIImage(systemName: "archivebox")
         
         let delete = UIContextualAction(style: .destructive, title: "Delete") { action, view, completion in
             NotificationCenter.default.post(name: .deleteIssue, object: nil, userInfo: ["index": indexPath])
             completion(true)
         }
+        delete.image = UIImage(systemName: "trash")
         
-        let configuration = UISwipeActionsConfiguration(actions: [delete, share])
+        let configuration = UISwipeActionsConfiguration(actions: [delete, close])
         configuration.performsFirstActionWithFullSwipe = false
         return configuration
     }

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
@@ -1,9 +1,0 @@
-//
-//  IssueTableDelegate.swift
-//  IssueTracker
-//
-//  Created by Lia on 2021/06/09.
-//
-
-import UIKit
-

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
@@ -7,28 +7,3 @@
 
 import UIKit
 
-extension IssueListViewController: UITableViewDelegate {
-    
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return UITableView.automaticDimension
-    }
-
-    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        
-        let close = UIContextualAction(style: .normal, title: "Close") { action, view, completion in
-            completion(true)
-        }
-        close.image = UIImage(systemName: "archivebox")
-        
-        let delete = UIContextualAction(style: .destructive, title: "Delete") { action, view, completion in
-            NotificationCenter.default.post(name: .deleteIssue, object: nil, userInfo: ["index": indexPath])
-            completion(true)
-        }
-        delete.image = UIImage(systemName: "trash")
-        
-        let configuration = UISwipeActionsConfiguration(actions: [delete, close])
-        configuration.performsFirstActionWithFullSwipe = false
-        return configuration
-    }
-    
-}

--- a/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
+++ b/ios/IssueTracker/IssueTracker/IssueList/ViewController/IssueTableDelegate.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class IssueTableDelegate: NSObject, UITableViewDelegate {
+extension IssueListViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension


### PR DESCRIPTION
## 작업 목록

### 경고창 기능
- [x] 삭제 시, 알럿 띄우기 기능
- [x] 삭제, 닫기에 이미지 추가하기

### 편집 기능
- [x] 편집 모드로 전환 시, UI 변화
  - 편집 버튼 → 취소 버튼
  - 이슈 라벨 텍스트 변경
  - 필터 버튼 숨기기
  - 하단 편집 창 띄우기
- [x] 셀 선택 기능
- [x] 셀 선택 시, 라벨 및 체크 버튼 UI 변화

## 추가 언급 사항
- IssueTableDelegate 파일의 내부 메소드를 뷰컨트롤러에 옮기고, 파일을 삭제했습니다.
- 기존에 노티를 주고받던 코드가 삭제되었습니다! :)
- UIView & UILabel의 animation 관련 코드는 Utility 그룹에 적혀있습니다.
- 테이블뷰에서 처리할 작업이 많아서.. MVVM 패턴이 제대로 안 지켜진 것 같습니다.

<image src ="https://user-images.githubusercontent.com/73650994/121642649-c65baa00-cacb-11eb-9d19-4623bd42c06b.gif" width = "300">
- 보시다시피 편집 모드 전환시 애니메이션이 동작하지 않습니다 (버그)